### PR TITLE
chore: Support the latest Eclipse (4.31) and CDT (11.5) with java 17

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -8,10 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
-    - name: Build with Maven
+        java-version: 17
+        distribution: 'temurin'
+        java-package: jdk
+    - name: Set up Maven 3.9.6
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.6
+    - name: Build with Maven (Java 17)
       run: mvn -B package --file com.googlecode.cppcheclipse.parent/pom.xml

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ It will not increment the version number nor deploy/publish/release the artifact
 
 **NOTES:**
 
+* This plugin was originally developed in [cppcheclipse project](https://github.com/kwin/cppcheclipse).
+* Maven (3.9+) build will work under Java 17.
 * Under Windows the `mvn clean verify` will fail because the unit test paths in unix format. As workaround skip the tests `mvn clean package` should build successfully, but it will not create.
-* Maven build will fail if Java 9 is used, while it will work under Java 8.
 
 
 Further information on how to use and install cppcheclipse can be found in the [wiki](https://github.com/kwin/cppcheclipse/wiki).

--- a/com.googlecode.cppcheclipse.core.tests/META-INF/MANIFEST.MF
+++ b/com.googlecode.cppcheclipse.core.tests/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.1.2.qualifier
 Bundle-Vendor: Konrad Windszus
 Fragment-Host: com.googlecode.cppcheclipse.core;bundle-version="0.9.8"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4;bundle-version="4.5.0"
+Require-Bundle: org.junit;bundle-version="4.13.2"

--- a/com.googlecode.cppcheclipse.feature/feature.xml
+++ b/com.googlecode.cppcheclipse.feature/feature.xml
@@ -218,10 +218,7 @@ litigation.
    </url>
 
    <requires>
-      <import plugin="org.eclipse.ui" version="3.4.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.core.runtime" version="3.4.0" match="greaterOrEqual"/>
       <import plugin="com.googlecode.cppcheclipse.core" version="1.0.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.core.resources" version="3.4.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.cdt.core" version="5.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.editors" version="3.4.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jface.text" version="3.4.0" match="greaterOrEqual"/>

--- a/com.googlecode.cppcheclipse.parent/pom.xml
+++ b/com.googlecode.cppcheclipse.parent/pom.xml
@@ -14,10 +14,31 @@
 	</prerequisites>
 
 	<properties>
-		<tycho-version>0.24.0</tycho-version>
+		<tycho-version>4.0.6</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
 	</properties>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <classifier>eclipse3.6cdtp2</classifier>
+            </properties>
+        </profile>
+        <profile>
+            <id>java17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <properties>
+                <classifier>eclipse4.31cdtp2</classifier>
+            </properties>
+        </profile>
+    </profiles>
 
 	<build>
 		<plugins>
@@ -39,7 +60,7 @@
 							<artifactId>com.googlecode.cppcheclipse.target</artifactId>
 							<groupId>com.googlecode.cppcheclipse</groupId>
 							<version>${project.version}</version>
-							<classifier>eclipse3.6cdtp2</classifier>
+							<classifier>${classifier}</classifier>
 						</artifact>
 					</target>
 					<ignoreTychoRepositories>true</ignoreTychoRepositories>

--- a/com.googlecode.cppcheclipse.target/eclipse4.31cdtp2.target
+++ b/com.googlecode.cppcheclipse.target/eclipse4.31cdtp2.target
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="Eclipse 4.31 CDT" sequenceNumber="6">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.platform.ide" version="4.31.0.I20240229-0520"/>
+<unit id="org.eclipse.sdk.feature.group" version="4.31.0.v20240229-1022"/>
+<unit id="org.eclipse.sdk.ide" version="4.31.0.I20240229-0520"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.31"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.cdt.feature.group" version="11.5.0.202403041627"/>
+<unit id="org.eclipse.cdt.sdk.feature.group" version="11.5.0.202403041627"/>
+<repository location="http://download.eclipse.org/tools/cdt/releases/11.5"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.apache.commons.codec" version="1.4.0.v201209201156"/>
+<unit id="org.apache.commons.io" version="2.0.1.v201105210651"/>
+<unit id="com.google.guava" version="12.0.0.v201212092141"/>
+<unit id="org.apache.commons.exec" version="1.1.0.v201301240602"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository/"/>
+</location>
+</locations>
+</target>

--- a/com.googlecode.cppcheclipse.target/pom.xml
+++ b/com.googlecode.cppcheclipse.target/pom.xml
@@ -11,7 +11,7 @@
 
 	<artifactId>com.googlecode.cppcheclipse.target</artifactId>
 	<packaging>pom</packaging>
-	
+
 	<build>
 		<plugins>
 			<plugin>
@@ -37,6 +37,11 @@
 									<type>target</type>
 									<classifier>eclipse4.3cdtp2</classifier>
 								</artifact>
+								<artifact>
+									<file>eclipse4.31cdtp2.target</file>
+									<type>target</type>
+									<classifier>eclipse4.31cdtp2</classifier>
+								</artifact>
 							</artifacts>
 						</configuration>
 					</execution>
@@ -44,6 +49,5 @@
 			</plugin>
 		</plugins>
 	</build>
-
 
 </project>

--- a/com.googlecode.cppcheclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/com.googlecode.cppcheclipse.ui.tests/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 1.1.2.qualifier
 Bundle-Vendor: Konrad Windszus
 Fragment-Host: com.googlecode.cppcheclipse.ui;bundle-version="0.9.8"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit4;bundle-version="4.8.1"
+Require-Bundle: org.junit;bundle-version="4.13.2"


### PR DESCRIPTION
This PR:

* upgrades the Tycho plugin to the latest (4.0.6) version
* adds the Eclipse (4.31) compilation target as well as the CDT 11.5
* sets up a Java 17 with Maven 3.9.6 Github CI pipeline